### PR TITLE
SDMC-3146: fix performance issue at unique_pool::prefill

### DIFF
--- a/src/recycle/unique_pool.hpp
+++ b/src/recycle/unique_pool.hpp
@@ -293,7 +293,7 @@ class unique_pool {
         void prefill(size_t count) {
             assert(m_allocate);
             lock_type lock(m_mutex);
-            while (m_free_list.size() < count) {
+            for (size_t pending = count - m_free_list.size(); pending > 0; pending--) {
                 value_ptr resource = m_allocate();
                 m_free_list.push_back(std::move(resource));
             }


### PR DESCRIPTION
**Performance fix for SDMC-3146.**
For detailed information, please see the latest updates of:
https://swxtchio.atlassian.net/browse/SDMC-3146

**Summary:**
In old versions of the C++ Standard Library (4.x and older), the `std::list::size()` method has a linear complexity, i.e., O(N), meaning it takes more time as more elements are in the list (it iterates over all of its elements to count them). A prefill method in recycle's unique_pool class was calling `size()` in every iteration of a while-loop; the iterations therefore take longer as the list grows, causing the buffer prefill operation to take 5 minutes for a 131,072 entries prefill. The fix proposed in this PR calls `list::size()` only once, to know how many entries are required to be created and added to the list, and uses a simple counter to limit the filling loop.